### PR TITLE
Added legacy mode for Odoo 7.0 and prior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Modest PHP class to manage OpenERP Json query.
 Code maturity
 -------------
 
-Early working alpha. Comments welcome. Although it was tested against OpenERP version 6.1 and 7.0.
+Early working alpha. Comments welcome. Although it was tested against OpenERP version 6.1, 7.0 and 8.0.
 
 
 Features
@@ -35,6 +35,7 @@ Features
 - Ability to resume an open session (and thus login in openerp) with a
   saved ``session_id`` and HTTP ``cookie_id`` (without ``$login`` and
   ``$password``)
+- Backwards compatiblity for Odoo 7.0 and prior with the legacy mode
 
 
 Usage
@@ -46,7 +47,7 @@ sample PHP code::
 
   require_once 'openerp.php';
 
-  $oe = new PhpOeJson\OpenERP("http://localhost:8069", "test_json");
+  $oe = new PhpOeJson\OpenERP("http://localhost:8069", "test_json", false /*set this to true for Odoo 7.0-*/);
   $oe->login("admin", "xxxxxx");
 
   echo "Logged in (session id: " . $oe->session_id . ")";

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ sample PHP code::
 
   require_once 'openerp.php';
 
-  $oe = new PhpOeJson\OpenERP("http://localhost:8069", "test_json", false /*set this to true for Odoo 7.0-*/);
+  $oe = new PhpOeJson\OpenERP("http://localhost:8069", "test_json");
   $oe->login("admin", "xxxxxx");
 
   echo "Logged in (session id: " . $oe->session_id . ")";

--- a/src/OpenERP.php
+++ b/src/OpenERP.php
@@ -22,9 +22,10 @@ class OpenERP {
                     'get_session_info' => "/web/session/get_session_info",
                     'destroy' => "/web/session/destroy");
 
-  function __construct($url, $db) {
+  function __construct($url, $db, $legacy = false) {
     $this->base = $url;
     $this->db = $db;
+    $this->legacy = $legacy;
 
     $this->cookie = False;
   }
@@ -34,13 +35,17 @@ class OpenERP {
    */
   public function login($login, $password) {
     $this->cookie = False; // will ask for a new cookie.
-    $req = $this->authenticate(array(
-        'base_location' => $this->base,
-        'db' => $this->db,
-        'login' => $login,
-        'password' => $password,
-        'session_id' => "",
-      ));
+    $data = array(
+      'base_location' => $this->base,
+      'db' => $this->db,
+      'login' => $login,
+      'password' => $password
+    );
+    
+    if ($this->legacy == true)
+      $data["session_id"] = "";
+    
+    $req = $this->authenticate($data);
     $this->session_id = $req['session_id'];
     $this->authenticated = $req["uid"] !== False;
     $this->uid = $req["uid"];
@@ -101,7 +106,7 @@ class OpenERP {
       $params = array();
     else
       $params = $params[0];
-    if (!array_key_exists("session_id", $params) && isset($this->session_id))
+    if ($this->legacy == true && !array_key_exists("session_id", $params) && isset($this->session_id))
         $params["session_id"] = $this->session_id;
     return $this->json($this->base  . $url, $params);
   }

--- a/src/OpenERP.php
+++ b/src/OpenERP.php
@@ -20,12 +20,12 @@ class OpenERP {
   var $urls = array('read' => "/web/dataset/search_read",
                     'authenticate' => "/web/session/authenticate",
                     'get_session_info' => "/web/session/get_session_info",
-                    'destroy' => "/web/session/destroy");
+                    'destroy' => "/web/session/destroy",
+                    'get_version_info' => "/web/webclient/version_info");
 
-  function __construct($url, $db, $legacy = false) {
+  function __construct($url, $db) {
     $this->base = $url;
     $this->db = $db;
-    $this->legacy = $legacy;
 
     $this->cookie = False;
   }
@@ -42,13 +42,23 @@ class OpenERP {
       'password' => $password
     );
     
-    if ($this->legacy == true)
-      $data["session_id"] = "";
-    
     $req = $this->authenticate($data);
     $this->session_id = $req['session_id'];
     $this->authenticated = $req["uid"] !== False;
     $this->uid = $req["uid"];
+    
+    //Get Odoo version
+    $req = $this->get_version_info();
+    if (floatval($req["server_serie"]) <= 7.0)
+    {
+      $this->legacy = true;
+    }
+    else
+    {
+      $this->legacy = false;
+    }
+    
+    var_dump($this->legacy);
 
     return $this->authenticated;
   }

--- a/src/OpenERP.php
+++ b/src/OpenERP.php
@@ -58,8 +58,6 @@ class OpenERP {
       $this->legacy = false;
     }
     
-    var_dump($this->legacy);
-
     return $this->authenticated;
   }
 


### PR DESCRIPTION
I fixed the `session_id` bug encountered with Odoo 8.0+ by adding a `legacy` boolean (`false` by default) in the constructor. If the legacy mode is enabled, the `session_id` attribute will be added to the JSON requests.

I tested it on the `107189-8-0-38c9de` Odoo 8.0 runbot and the connection works. I couldn't test further because I couldn't get a working example (even with the one you provide, so I guess that it comes from the runbot), I get a Odoo server error that I'm not able to check.

If you know how to see the runbot's logs then tell me and I will check what is causing this error, but it's not from me, the merge will just be safer.
